### PR TITLE
add logging

### DIFF
--- a/core/src/main/java/com/thoughtworks/ark/core/logging/Logger.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/Logger.kt
@@ -1,0 +1,110 @@
+package com.thoughtworks.ark.core.logging
+
+import com.thoughtworks.ark.core.logging.formatter.DefaultFormatter
+import com.thoughtworks.ark.core.logging.formatter.Formatter
+import com.thoughtworks.ark.core.logging.formatter.SecurityFormatter
+import com.thoughtworks.ark.core.logging.interceptor.Interceptor
+import com.thoughtworks.ark.core.logging.interceptor.LogLevelInterceptor
+import com.thoughtworks.ark.core.logging.printer.AndroidPrinter
+import com.thoughtworks.ark.core.logging.printer.Printer
+import com.thoughtworks.ark.core.utils.isDevEnvironment
+
+class Logger private constructor() {
+    data class Strategy(
+        val globalTag: String? = null,
+        val interceptors: List<Interceptor> = emptyList(),
+        val dataFormatter: Formatter = if (isDevEnvironment()) DefaultFormatter() else SecurityFormatter(),
+        val printers: List<Printer> = emptyList()
+    )
+
+    class StrategyGenerator {
+        private var globalTag: String? = null
+        private var interceptors: MutableList<Interceptor> = mutableListOf()
+        private var dataFormatter: Formatter = if (isDevEnvironment()) DefaultFormatter() else SecurityFormatter()
+        private var printers: MutableList<Printer> = mutableListOf()
+
+        fun setLogLevel(level: Int) {
+            if (level > 0) {
+                interceptors.add(LogLevelInterceptor(logLevel = level))
+            }
+        }
+
+        fun setTag(tag: String?) {
+            globalTag = tag
+        }
+
+        fun addInterceptor(interceptor: Interceptor) {
+            interceptors.add(interceptor)
+        }
+
+        fun setFormatter(formatter: Formatter) {
+            dataFormatter = formatter
+        }
+
+        fun addPrinter(printer: Printer) {
+            printers.add(printer)
+        }
+
+        internal fun generate(configuration: (StrategyGenerator) -> Unit): Strategy {
+            configuration(this)
+            return Strategy(
+                globalTag,
+                interceptors,
+                dataFormatter,
+                printers
+            )
+        }
+    }
+
+    companion object Default: Logging() {
+        private val logcatStrategy = Strategy(
+            interceptors = listOf(LogLevelInterceptor(0)),
+            printers = listOf(AndroidPrinter())
+        )
+
+        private lateinit var strategy: Strategy
+
+        override val globalTag: String?
+            get() = strategy.globalTag
+
+        @Synchronized
+        fun setUp(loggerStrategy: Strategy = logcatStrategy) {
+            require(loggerStrategy.printers.isNotEmpty()) { "There has to be a printer" }
+            if (!this::strategy.isInitialized) {
+                strategy = loggerStrategy
+            }
+        }
+
+        @Synchronized
+        fun setUp(configure: (StrategyGenerator) -> Unit) {
+            val loggerStrategy = StrategyGenerator().generate(configure)
+            require(loggerStrategy.printers.isNotEmpty()) { "There has to be a printer" }
+            if (!this::strategy.isInitialized) {
+                strategy = loggerStrategy
+            }
+        }
+
+        /**
+         * Set tag for next log call, will be clear after the call
+         */
+        fun onceTag(tag: String): Logging {
+            userTag.set(tag)
+            return this
+        }
+
+        override fun printLog(priority: Int, tag: String?, message: String) {
+            require(this::strategy.isInitialized) { "Logger is not setup" }
+            strategy.printers.forEach { it.printLog(priority, tag, message) }
+        }
+
+        override fun isLoggable(tag: String?, priority: Int): Boolean {
+            require(this::strategy.isInitialized) { "Logger is not setup" }
+            return strategy.interceptors.any { it.intercept(tag, priority) }.not()
+        }
+
+        override fun formatMessage(message: String, args: Array<out Any?>): String {
+            require(this::strategy.isInitialized) { "Logger is not setup" }
+            return strategy.dataFormatter.format(message, args)
+        }
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/Logging.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/Logging.kt
@@ -1,0 +1,193 @@
+package com.thoughtworks.ark.core.logging
+
+import android.util.Log
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.regex.Pattern
+import kotlin.math.min
+
+abstract class Logging {
+    companion object {
+        private const val MAX_TAG_LENGTH = 23
+        private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
+    }
+
+    protected open val globalTag: String? = null
+    protected val userTag = ThreadLocal<String>()
+    private val tag: String?
+        get() {
+            val tag = userTag.get()
+            if (tag != null) {
+                userTag.remove()
+            }
+            return tag ?: globalTag ?: Throwable().stackTrace
+                .first { it.className !in classesIgnore }
+                .let(::createStackElementTag)
+        }
+
+    private val classesIgnore = listOf(
+        Logger::class.java.name,
+        Logger.Default::class.java.name,
+        Logging::class.java.name
+    )
+
+    /**
+     * Extract the tag from the element.
+     *
+     * This will not be called if a [tag] was specified.
+     */
+    protected open fun createStackElementTag(element: StackTraceElement): String? {
+        var tag = element.className.substringAfterLast('.')
+        val matcher = ANONYMOUS_CLASS.matcher(tag)
+        if (matcher.find()) {
+            tag = matcher.replaceAll("")
+        }
+        return if (tag.length <= MAX_TAG_LENGTH) {
+            tag
+        } else {
+            tag.substring(0, MAX_TAG_LENGTH)
+        }
+    }
+    /** Log a verbose message */
+    open fun v(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.VERBOSE, null, message, *args)
+    }
+
+    /** Log a verbose exception and a message */
+    open fun v(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.VERBOSE, throwable, message, *args)
+    }
+
+    /** Log a verbose exception. */
+    open fun v(throwable: Throwable?) {
+        prepareAndPrint(Log.VERBOSE, throwable, null)
+    }
+
+    /** Log a debug message */
+    open fun d(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.DEBUG, null, message, *args)
+    }
+
+    /** Log a debug exception and a message */
+    open fun d(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.DEBUG, throwable, message, *args)
+    }
+
+    /** Log a debug exception. */
+    open fun d(throwable: Throwable?) {
+        prepareAndPrint(Log.DEBUG, throwable, null)
+    }
+
+    /** Log an info message */
+    open fun i(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.INFO, null, message, *args)
+    }
+
+    /** Log an info exception and a message */
+    open fun i(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.INFO, throwable, message, *args)
+    }
+
+    /** Log an info exception. */
+    open fun i(throwable: Throwable?) {
+        prepareAndPrint(Log.INFO, throwable, null)
+    }
+
+    /** Log a warning message */
+    open fun w(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.WARN, null, message, *args)
+    }
+
+    /** Log a warning exception and a message */
+    open fun w(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.WARN, throwable, message, *args)
+    }
+
+    /** Log a warning exception. */
+    open fun w(throwable: Throwable?) {
+        prepareAndPrint(Log.WARN, throwable, null)
+    }
+
+    /** Log an error message */
+    open fun e(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.ERROR, null, message, *args)
+    }
+
+    /** Log an error exception and a message */
+    open fun e(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.ERROR, throwable, message, *args)
+    }
+
+    /** Log an error exception. */
+    open fun e(throwable: Throwable?) {
+        prepareAndPrint(Log.ERROR, throwable, null)
+    }
+
+    /** Log an assert message */
+    open fun wtf(message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.ASSERT, null, message, *args)
+    }
+
+    /** Log an assert exception and a message */
+    open fun wtf(throwable: Throwable?, message: String?, vararg args: Any?) {
+        prepareAndPrint(Log.ASSERT, throwable, message, *args)
+    }
+
+    /** Log an assert exception. */
+    open fun wtf(throwable: Throwable?) {
+        prepareAndPrint(Log.ASSERT, throwable, null)
+    }
+
+    private fun prepareAndPrint(priority: Int, throwable: Throwable?, message: String?, vararg args: Any?) {
+        // Consume tag even not loggable, make sure next message is correctly tagged.
+        val tag = tag
+        if (!isLoggable(tag, priority)) {
+            return
+        }
+
+        var msg = message
+        if (msg.isNullOrEmpty()) {
+            if (throwable == null) {
+                return  // Swallow message if it's null and there's no throwable.
+            }
+            msg = getStackTraceString(throwable)
+        } else {
+            if (args.isNotEmpty()) {
+                msg = formatMessage(msg, args)
+            }
+            if (throwable != null) {
+                msg += "\n" + getStackTraceString(throwable)
+            }
+        }
+
+        printLog(priority, tag, msg)
+    }
+
+    private fun getStackTraceString(throwable: Throwable): String {
+        val sw = StringWriter(256)
+        val pw = PrintWriter(sw, false)
+        throwable.printStackTrace(pw)
+        pw.flush()
+        return sw.toString()
+    }
+
+    /**
+     * For interceptors
+     */
+    protected abstract fun isLoggable(tag: String?, priority: Int): Boolean
+
+    /**
+     * For formatters
+     */
+    protected abstract fun formatMessage(message: String, args: Array<out Any?>): String
+
+    /**
+     * For printers
+     * Write log message to its destination.
+     *
+     * @param priority Log level. See [Log] for constants.
+     * @param tag Explicit or inferred tag. May be `null`.
+     * @param message Formatted log message.
+     */
+    protected abstract fun printLog(priority: Int, tag: String?, message: String)
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/DefaultFormatter.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/DefaultFormatter.kt
@@ -1,0 +1,8 @@
+package com.thoughtworks.ark.core.logging.formatter
+
+class DefaultFormatter: Formatter {
+
+    override fun format(message: String, args: Array<out Any?>): String {
+        return message.format(*args)
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/Formatter.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/Formatter.kt
@@ -1,0 +1,9 @@
+package com.thoughtworks.ark.core.logging.formatter
+
+interface Formatter {
+
+    /**
+     * Format the [message] with [args]
+     */
+    fun format(message: String, args: Array<out Any?>): String
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/SecurityFormatter.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/formatter/SecurityFormatter.kt
@@ -1,0 +1,9 @@
+package com.thoughtworks.ark.core.logging.formatter
+
+class SecurityFormatter: Formatter {
+    private val formatSpecifierRegex = "%(\\d+\\$)?([-#+ 0,(<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])".toRegex()
+
+    override fun format(message: String, args: Array<out Any?>): String {
+        return message.replace(formatSpecifierRegex, "****")
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/BlockedInterceptor.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/BlockedInterceptor.kt
@@ -1,0 +1,8 @@
+package com.thoughtworks.ark.core.logging.interceptor
+
+class BlockedInterceptor(private val tags: List<String>): Interceptor {
+
+    override fun intercept(tag: String?, priority: Int): Boolean {
+        return tags.contains(tag)
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/Interceptor.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/Interceptor.kt
@@ -1,0 +1,11 @@
+package com.thoughtworks.ark.core.logging.interceptor
+
+interface Interceptor {
+
+    /**
+     * Decide whether to disable this log according to [priority] and [tag]
+     *
+     * @return true to disable this log
+     */
+    fun intercept(tag: String?, priority: Int): Boolean = false
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/LogLevelInterceptor.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/interceptor/LogLevelInterceptor.kt
@@ -1,0 +1,10 @@
+package com.thoughtworks.ark.core.logging.interceptor
+
+import android.util.Log
+
+class LogLevelInterceptor(private val logLevel: Int = Log.VERBOSE) : Interceptor {
+
+    override fun intercept(tag: String?, priority: Int): Boolean {
+        return priority < logLevel
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/AndroidPrinter.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/AndroidPrinter.kt
@@ -1,0 +1,19 @@
+package com.thoughtworks.ark.core.logging.printer
+
+import android.util.Log
+import com.thoughtworks.ark.core.logging.printer.decoration.Decoration
+
+class AndroidPrinter(decorations: List<Decoration> = emptyList()): Printer(decorations) {
+
+    override fun printLog(priority: Int, tag: String?, message: String) {
+        if (priority == Log.ASSERT) {
+            Log.wtf(tag, message)
+        } else {
+            super.printLog(priority, tag, message)
+        }
+    }
+
+    override fun printLine(priority: Int, tag: String?, message: String) {
+        Log.println(priority, tag, message)
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/ConsolePrinter.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/ConsolePrinter.kt
@@ -1,0 +1,9 @@
+package com.thoughtworks.ark.core.logging.printer
+
+import com.thoughtworks.ark.core.logging.printer.decoration.Decoration
+
+class ConsolePrinter(decorations: List<Decoration> = emptyList()): Printer(decorations) {
+    override fun printLine(priority: Int, tag: String?, message: String) {
+        println("$tag $message")
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/Printer.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/Printer.kt
@@ -1,0 +1,83 @@
+package com.thoughtworks.ark.core.logging.printer
+
+import android.util.Log
+import com.thoughtworks.ark.core.logging.printer.decoration.Decoration
+import kotlin.math.min
+
+/**
+ * An output stream to print formatted log
+ */
+abstract class Printer(private val decorations: List<Decoration>) {
+
+    /**
+     * Each log call will call this method once to print log
+     */
+    open fun printLog(priority: Int, tag: String?, message: String) {
+        val starts = decorations.map { it.start().orEmpty() }
+        printHeaders(starts, priority, tag)
+        spiltToLines(message).forEach {
+            printLine(priority, tag, "${starts.joinToString("")}$it")
+        }
+        printFooters(starts, priority, tag)
+    }
+
+    /**
+     * Each log line will call this method once
+     */
+    protected abstract fun printLine(priority: Int, tag: String?, message: String)
+
+    private fun printHeaders(starts: List<String>, priority: Int, tag: String?) {
+        decorations.forEachIndexed { index, decoration ->
+            decoration.header()?.let { header ->
+                printLine(priority, tag, "${starts.subList(0, index).joinToString("")}$header")
+            }
+        }
+    }
+
+    private fun printFooters(starts: List<String>, priority: Int, tag: String?) {
+        decorations.reversed().forEachIndexed { index, decoration ->
+            decoration.footer()?.let { footer ->
+                printLine(priority, tag, "${starts.subList(0, starts.size - index - 1).joinToString("")}$footer")
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_LOG_LENGTH = 4000
+
+        fun spiltToLines(message: String): List<String> {
+            val rawLines = message.split('\n')
+            if (rawLines.all { it.length < MAX_LOG_LENGTH}) {
+                return rawLines
+            }
+
+            val lines = mutableListOf<String>()
+            rawLines.forEach {
+                val length = it.length
+                if (length < MAX_LOG_LENGTH) {
+                    lines.add(it)
+                } else {
+                    var i = 0
+                    while (i < length) {
+                        val end = min(length, i + MAX_LOG_LENGTH)
+                        lines.add(message.substring(i, end))
+                        i = end
+                    }
+                }
+            }
+            return lines.toList()
+        }
+
+        fun logLevel(priority: Int): String {
+            return when (priority) {
+                Log.VERBOSE -> "V"
+                Log.DEBUG -> "D"
+                Log.WARN -> "W"
+                Log.INFO -> "I"
+                Log.ERROR -> "E"
+                Log.ASSERT -> "F"
+                else -> ""
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/BorderDecoration.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/BorderDecoration.kt
@@ -1,0 +1,12 @@
+package com.thoughtworks.ark.core.logging.printer.decoration
+
+class BorderDecoration: Decoration {
+
+    private val header = "╔═════════════════════════════════"
+    private val start =  "║ "
+    private val footer = "╚═════════════════════════════════"
+
+    override fun header() = header
+    override fun footer() = footer
+    override fun start() = start
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/Decoration.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/Decoration.kt
@@ -1,0 +1,20 @@
+package com.thoughtworks.ark.core.logging.printer.decoration
+
+/**
+ * Add extra info for each basic call
+ */
+interface Decoration {
+
+    /**
+     * Add a line before log call
+     */
+    fun header(): String? = null
+    /**
+     * Add extra info before log line
+     */
+    fun start(): String? = null
+    /**
+     * Add a line after log call
+     */
+    fun footer(): String? = null
+}

--- a/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/ThreadInfoDecoration.kt
+++ b/core/src/main/java/com/thoughtworks/ark/core/logging/printer/decoration/ThreadInfoDecoration.kt
@@ -1,0 +1,8 @@
+package com.thoughtworks.ark.core.logging.printer.decoration
+
+class ThreadInfoDecoration: Decoration {
+
+    override fun header(): String {
+        return "Thread: ${Thread.currentThread().name}"
+    }
+}


### PR DESCRIPTION
## Overview

Add logging in `core` and wrap `Logger` for all log printing.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## In the scope

- Add `Logger` for logging
- `Strategy` for configuration
  - `globalTag` to replace auto generated tag by class name
  - `Interceptor`s to disable log message to be printed, via `tag` or `log level`
  - `Formatter` to format the message
  - `Printer`s to print log in Logcat, Console or other custom printers

- Built-in configuration
  - Interceptor: `LogLevelInterceptor`, `BlockedInterceptor`
  - Formatter: `DefaultFormatter`, `SecurityFormatter`
  - Printer: `AndroidPrinter`, `ConsolePrinter`

Details on [Wiki](https://github.com/TW-Smart-CoE/ARK-WIKI/blob/main/docs/android/modules/log.md)

## Out of scope

## Checklist
1. [x] Makes your submission pass tests?
2. [x] Have you lint your code locally before submission?
3. [x] Have you updated the wiki of your change?

## Reference
- Card: [#25 logging](https://trello.com/c/QCxxldfR/25-2-logging).
- Related PR: N/A.